### PR TITLE
Zoom duration stuff. Includes:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-dotenv==0.7.1
 requests[security]==2.8.1
 redis==2.10.6
 maxminddb==1.3.0
+pytimeparse==1.1.7
 
 # Elasticsearch 2.x
 elasticsearch>=2,<3


### PR DESCRIPTION
* use `pytimeparse` as fallback for meeting duration parsing
* calc a session duration value based on join/leave times